### PR TITLE
change version requirement for google api python client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-google-api-python-client==1.10.0
+google-api-python-client>=1.7.8


### PR DESCRIPTION
allow a much wider range of versions for google-api-python-client