### PR TITLE
Sheet tab creation

### DIFF
--- a/pysuite/sheets.py
+++ b/pysuite/sheets.py
@@ -113,3 +113,15 @@ class Sheets:
         values = df.fillna('').values.tolist()
         values.insert(0, list(df.columns))
         self.upload(values, id=id, range=range)
+
+    def create_spreadsheet(self, name: str) -> str:
+        """create a spreadsheet with requested name.
+
+        :param name: name of the created sheet.
+        :return: id of the spreadsheet
+        """
+        file_metadata = {
+            "properties": {"title": name}
+        }
+        response = self._service.create(body=file_metadata, fields="spreadsheetId").execute()
+        return response.get("spreadsheetId")

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -13,8 +13,7 @@ def purge_temp_file(drive_auth):
     test_suffix = "_"+str(uuid.uuid4())
 
     def purge():
-        temp_objects = drive.list(id=TEST_DRIVE_FOLDER_ID, regex=f"^{TEST_PREFIX}.*^{test_suffix}$", recursive=True,
-                                  depth=5)
+        temp_objects = drive.find(name_contains=test_suffix, parent_id=TEST_DRIVE_FOLDER_ID)
         for object in temp_objects:
             drive.delete(object["id"])
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -17,7 +17,6 @@ def purge_temp_file(drive_auth):
         for object in temp_objects:
             drive.delete(object["id"])
 
-    purge()
     yield test_suffix
     purge()
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,0 +1,28 @@
+import pytest
+import uuid
+from tests.test_auth import drive_auth
+from pysuite import Drive
+
+TEST_PREFIX = "_pysuite_test_tmp_"
+TEST_DRIVE_FOLDER_ID = "11dtprloqhpATi_awh8LAy_5xuCqTk1Ok"
+
+
+@pytest.fixture(scope="session")
+def purge_temp_file(drive_auth):
+    drive = Drive(service=drive_auth.get_service_client())
+    test_suffix = "_"+str(uuid.uuid4())
+
+    def purge():
+        temp_objects = drive.list(id=TEST_DRIVE_FOLDER_ID, regex=f"^{TEST_PREFIX}.*^{test_suffix}", recursive=True, depth=5)
+        for object in temp_objects:
+            drive.delete(object["id"])
+
+    purge()
+    yield test_suffix
+    purge()
+
+
+
+
+
+

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -13,7 +13,8 @@ def purge_temp_file(drive_auth):
     test_suffix = "_"+str(uuid.uuid4())
 
     def purge():
-        temp_objects = drive.list(id=TEST_DRIVE_FOLDER_ID, regex=f"^{TEST_PREFIX}.*^{test_suffix}", recursive=True, depth=5)
+        temp_objects = drive.list(id=TEST_DRIVE_FOLDER_ID, regex=f"^{TEST_PREFIX}.*^{test_suffix}$", recursive=True,
+                                  depth=5)
         for object in temp_objects:
             drive.delete(object["id"])
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -61,7 +61,7 @@ def test_when_credential_file_has_incorrect_format_raise_exception(tmpdir, crede
         Authentication(credential=temp_credential_file, token=drive_token_file, services="drive")
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def drive_auth():
     return Authentication(credential=credential_file, token=drive_token_file, services="drive")
 
@@ -71,7 +71,7 @@ def test_get_client_no_service_provided_return_correct_values(drive_auth):
     assert isinstance(result, Resource)
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def sheets_auth():
     return Authentication(credential=credential_file, token=sheet_token_file, services="sheets")
 
@@ -81,7 +81,7 @@ def test_get_client_service_authorized_return_correct_values(sheets_auth):
     assert isinstance(result, Resource)
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def multi_auth():
     return Authentication(credential=credential_file, token=both_token_file, services=["drive", "sheets"])
 

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from pysuite.drive import Drive
 from googleapiclient.errors import HttpError
 
-from tests.test_auth import drive_auth
-from tests.helper import TEST_PREFIX
+from tests.test_auth import drive_auth, multi_auth
+from tests.helper import TEST_PREFIX, purge_temp_file
 
 
 @pytest.fixture()
@@ -41,11 +41,12 @@ def test_download_create_file_correctly(drive, tmpdir):
     assert result == ["hello", "world"]
 
 
-def test_upload_and_delete_correctly_create_and_remove_file(drive, tmpdir):
+def test_upload_and_delete_correctly_create_and_remove_file(drive, purge_temp_file, tmpdir):
     file_to_upload = Path(tmpdir.join("test_upload_file"))
     file_to_upload.write_text("hello world")
-
-    id = drive.upload(from_file=file_to_upload, name=f"{TEST_PREFIX}test_file", parent_ids=["1_p0khJ5euUDbZhWiXbN5fefozKMD28yZ"])
+    suffix = purge_temp_file
+    id = drive.upload(from_file=file_to_upload, name=f"{TEST_PREFIX}test_file{suffix}",
+                      parent_ids=["1_p0khJ5euUDbZhWiXbN5fefozKMD28yZ"])
 
     download_file = Path(tmpdir.join("test_downloaded_file"))
     drive.download(id=id, to_file=download_file)
@@ -62,10 +63,11 @@ def test_upload_and_delete_correctly_create_and_remove_file(drive, tmpdir):
 
 
 @pytest.fixture()
-def clean_up_file(drive, tmpdir):
+def clean_up_file(drive, tmpdir, purge_temp_file):
     file_to_upload = Path(tmpdir.join("test_upload_file"))
     file_to_upload.write_text("hello world")
-    id = drive.upload(from_file=file_to_upload, name=f"{TEST_PREFIX}drive_test_file")
+    suffix = purge_temp_file
+    id = drive.upload(from_file=file_to_upload, name=f"{TEST_PREFIX}drive_test_file{suffix}")
 
     yield id
 
@@ -131,9 +133,10 @@ def clean_folder(drive):
         drive.delete(item['id'])
 
 
-def test_create_folder_correctly(drive, clean_folder):
-    folder_id = clean_folder
-    expected = f"{TEST_PREFIX}create_folder"
+def test_create_folder_correctly(drive, clean_folder, purge_temp_file):
+    folder_id = "1iUzQwHtr3KE_jR3AGo2-Qjq_5v99eh5u"
+    suffix = purge_temp_file
+    expected = f"{TEST_PREFIX}create_folder{suffix}"
     id = drive.create_folder(expected, parent_ids=[folder_id])
     result = drive.get_name(id)
     assert result == expected

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -148,3 +148,24 @@ def test_multi_auth_token(multi_auth):
     expected = "drive_test_file"
     assert result == expected
 
+
+@pytest.mark.parametrize(("contains", "not_contains", "expected"),
+                         [
+                             ("positive", None,
+                              [{'id': '1MmgjCLivbb-EPkHplTuNIDgj1Ma9wQw4', 'name': 'positive_c_negative'},
+                               {'id': '1pkokaiJP9d0V_eaY4_H_Du4g5AfCG5Er', 'name': 'positive_b'},
+                               {'id': '1S_QfcIiBaxhoAnq1csciQuEr4wz4mYh-', 'name': 'positive_a'}]),
+                             ("a", None,
+                              [{'id': '17tXdw1kQHuxdrcbkKYz81862UP2s6x2a', 'name': 'aa'}]),
+                             ("positive", "negative",
+                              [{'id': '1pkokaiJP9d0V_eaY4_H_Du4g5AfCG5Er', 'name': 'positive_b'},
+                               {'id': '1S_QfcIiBaxhoAnq1csciQuEr4wz4mYh-', 'name': 'positive_a'}]),
+                             (None, "negative",
+                              [{'id': '17tXdw1kQHuxdrcbkKYz81862UP2s6x2a', 'name': 'aa'},
+                               {'id': '1pkokaiJP9d0V_eaY4_H_Du4g5AfCG5Er', 'name': 'positive_b'},
+                               {'id': '1S_QfcIiBaxhoAnq1csciQuEr4wz4mYh-', 'name': 'positive_a'}]
+)
+                         ])
+def test_find_return_correct_values(drive, contains, not_contains, expected):
+    result = drive.find(name_contains=contains, name_not_contains=not_contains, parent_id="1LOeJyQpD8tqXF5sm6cqpmOPcTBEg6NaE")
+    assert sorted(result, key=lambda x: x['name']) == sorted(expected, key=lambda x: x['name'])

--- a/tests/test_sheet.py
+++ b/tests/test_sheet.py
@@ -5,8 +5,11 @@ from pandas.testing import assert_frame_equal
 
 from pysuite.sheets import Sheets
 from tests.test_auth import sheets_auth, multi_auth
+from tests.test_drive import drive, drive_auth
+from tests.helper import TEST_PREFIX, purge_temp_file
 
 test_sheet_id = "1CNOH3o2Zz05mharkLXuwX72FpRka8-KFpIm9bEaja50"
+test_sheet_folder = "1qqFJ-OaV1rdPSeFtdaf6lUwFIpupOiiF"
 
 
 @pytest.fixture()
@@ -114,3 +117,17 @@ def test_multi_auth_token(multi_auth):
         "col3": ["10.15", "20.2", "0.59"]
     })
     assert_frame_equal(result, expected)
+
+
+@pytest.fixture()
+def clean_up_created_spreadsheet(sheets, drive, purge_temp_file):
+    suffix = purge_temp_file
+    id = sheets.create_spreadsheet(f"{TEST_PREFIX}test_sheet{suffix}")
+    yield id
+    drive.delete(id)
+
+
+def test_create_spreadsheet_create_correctly(sheets, clean_up_created_spreadsheet):
+    id = clean_up_created_spreadsheet
+    result = sheets.download(id=id, range="Sheet1!A1:B2")
+    assert result == []  # file created correctly


### PR DESCRIPTION
## New:
### Drive
- `Drive.find`: find file whose name contain and/or do not contain certain string
- `Drive.list`: add ability to recursively list file

### Sheet
- `Sheet.create_spreadsheet`: create spreadsheet

## Changed:
### tests:
- newly created file now have unique suffix for different session, this helps reduce parallel test conflicts.
- add global purge fixture.
