### PR TITLE
Only allow single parent

### DIFF
--- a/docs/source/user_manual.rst
+++ b/docs/source/user_manual.rst
@@ -106,12 +106,12 @@ download a file to local.
 
 upload
 ++++++
-upload a local file to google drive. you can provide a list of ids to place the uploaded file under these folders.
+upload a local file to google drive. you can provide the id of a folder to place the uploaded file under that folder.
 
 .. code-block:: python
 
     drive.upload(from_file="path/to/your/file/to/be/uploaded", name="google_drive_file_name",
-                 parent_ids=["google drive folder id 1", "google drive folder id 2"])
+                 parent_id="google drive folder id 1")
 
 delete
 ++++++
@@ -123,11 +123,11 @@ delete a google drive file/folder. parameter `recursive` has not been implemente
 
 copy
 ++++
-copy one google drive file to another. you can provide a list of ids to place the new file under these folders.
+copy one google drive file to another. you can provide the id of a folder to place the new file under that folder.
 
 .. code-block:: python
 
-    drive.copy(id="id_of_target_file", name="name of new file", parent_ids=["new parent folder id"])
+    drive.copy(id="id_of_target_file", name="name of new file", parent_id="new parent folder id")
 
 list
 ++++

--- a/pysuite/drive.py
+++ b/pysuite/drive.py
@@ -30,26 +30,20 @@ class Drive:
                 logging.info(f"Download {status.progress()*100}%")
 
     def upload(self, from_file: Union[str, PosixPath], name: Optional[str]=None, mimetype: Optional[str]=None,
-               parent_ids: Optional[List[str]]=None) -> str:
+               parent_id: Optional[str]=None) -> str:
         """upload local file to gdrive.
 
         :param from_file: path to local file.
         :param name: name of google drive file. If None, the name of local file will be used.
         :param mimetype: Mime-type of the file. If None then a mime-type will be guessed from the file extension.
-        :param parent_ids: list of ids for the folder you want to upload the file to. If None, it will be uploaded to
+        :param parent_id: id of the folder you want to upload the file to. If None, it will be uploaded to
           root of Google drive.
         :return: id of the uploaded file
         """
         file_metadata = {'name': name if name is not None else Path(from_file).name}
 
-        if parent_ids is not None:
-            if not isinstance(parent_ids, list):
-                raise TypeError(f"parent_ids must be a list. got {type(parent_ids)}")
-
-            if len(parent_ids) == 0:
-                raise ValueError(f"parent_ids cannot be empty")
-
-            file_metadata["parents"] = parent_ids
+        if parent_id is not None:
+            file_metadata["parents"] = parent_id
 
         media = MediaFileUpload(str(from_file),
                                 mimetype=mimetype,

--- a/pysuite/drive.py
+++ b/pysuite/drive.py
@@ -244,16 +244,17 @@ class Drive:
         file = self._service.files().get(fileId=id).execute()
         return file['name']
 
-    def copy(self, id: str, name: str, parent_ids: Optional[list]=None) -> str:
+    def copy(self, id: str, name: str, parent_id: Optional[str]=None) -> str:
         """copy target file and give the new file specified name. return the id of the created file.
 
         :param id: target file to be copied.
         :param name: name of the new file.
-        :param parent_ids: ids of folders to place the new file in.
+        :param parent_id: the id of the folder where the new file is placed in. If None, the file will be placed in
+            Google Drive root.
         :return: id of the created new file.
         """
         request = {"name": name}
-        if parent_ids is not None:
-            request["parents"] = parent_ids
+        if parent_id is not None:
+            request["parents"] = parent_id
         file = self._service.files().copy(fileId=id, body=request, fields='id').execute()
         return file.get("id")

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -175,7 +175,7 @@ def test_find_return_correct_values(drive, contains, not_contains, expected):
 def test_copy_copy_file_correctly(drive, clean_up_drive_temp_files, tmpdir):
     prefix = clean_up_drive_temp_files
     id = drive.copy(id="1-zIfn0kUcK6KI9PfZLXu6uCt01ZSOTOZ", name=f"{prefix}_copied_file",
-                    parent_ids=["1_p0khJ5euUDbZhWiXbN5fefozKMD28yZ"])
+                    parent_id="1_p0khJ5euUDbZhWiXbN5fefozKMD28yZ")
     temp_download = Path(tmpdir.join("temp_download_copied_file"))
     drive.download(id=id, to_file=temp_download)
     with open(temp_download) as f:

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -51,7 +51,7 @@ def test_upload_and_delete_correctly_create_and_remove_file(drive, prefix, tmpdi
     file_to_upload = Path(tmpdir.join("test_upload_file"))
     file_to_upload.write_text("hello world")
     id = drive.upload(from_file=file_to_upload, name=f"{prefix}test_file",
-                      parent_ids=["1_p0khJ5euUDbZhWiXbN5fefozKMD28yZ"])
+                      parent_id="1_p0khJ5euUDbZhWiXbN5fefozKMD28yZ")
 
     download_file = Path(tmpdir.join("test_downloaded_file"))
     drive.download(id=id, to_file=download_file)
@@ -72,7 +72,7 @@ def clean_up_update(drive, tmpdir, prefix):
     file_to_upload = Path(tmpdir.join("test_upload_file"))
     file_to_upload.write_text("hello world")
     id = drive.upload(from_file=file_to_upload, name=f"{prefix}drive_test_file",
-                      parent_ids=[TEST_DRIVE_FOLDER_ID])
+                      parent_id=TEST_DRIVE_FOLDER_ID)
     yield id
     purge_temp_file(drive, prefix)
 


### PR DESCRIPTION
# Changed
## Drive
`upload` and `copy` now can only put the new file in one parent folder. This change is enforced by [Google's update](https://tech.hindustantimes.com/tech/news/google-rolls-out-shortcuts-to-drive-structural-changes-to-follow-on-september-30-story-wiGGcKcposN87m4OYP4B3H.html).