### PR TITLE
allow retry on quota exceeded error

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,7 +15,7 @@ Welcome to pysuite's documentation!
    drive
    sheets
    gmail
-
+   utilities
 
 Indices and tables
 ==================

--- a/docs/source/utilities.rst
+++ b/docs/source/utilities.rst
@@ -1,0 +1,9 @@
+.. _utilities:
+
+utilities
+=========
+
+.. automodule:: pysuite.utilities
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/pysuite/drive.py
+++ b/pysuite/drive.py
@@ -12,8 +12,16 @@ from pysuite.utilities import retry_on_out_of_quota, MAX_RETRY_ATTRIBUTE, SLEEP_
 
 
 class Drive:
+    """Class to interact with Google Drive API
+    """
 
     def __init__(self, service: Resource, max_retry: int=0, sleep: int=5):
+        """
+
+        :param service: an authorized Google Drive service client.
+        :param max_retry: max number of retry on quota exceeded error. if 0 or less, no retry will be attempted.
+        :param sleep: base number of seconds between retries. the sleep time is exponentially increased after each retry.
+        """
         self._service = service
         setattr(self, MAX_RETRY_ATTRIBUTE, max_retry)
         setattr(self, SLEEP_ATTRIBUTE, sleep)

--- a/pysuite/drive.py
+++ b/pysuite/drive.py
@@ -8,12 +8,17 @@ import re
 from googleapiclient.discovery import Resource
 from googleapiclient.http import MediaIoBaseDownload, MediaFileUpload
 
+from pysuite.utilities import retry_on_out_of_quota, MAX_RETRY_ATTRIBUTE, SLEEP_ATTRIBUTE
+
 
 class Drive:
 
-    def __init__(self, service: Resource):
+    def __init__(self, service: Resource, max_retry: int=0, sleep: int=5):
         self._service = service
+        setattr(self, MAX_RETRY_ATTRIBUTE, max_retry)
+        setattr(self, SLEEP_ATTRIBUTE, sleep)
 
+    @retry_on_out_of_quota()
     def download(self, id: str, to_file: Union[str, PosixPath]):
         """download the google drive file with the requested id to target local file.
 
@@ -29,6 +34,7 @@ class Drive:
                 status, done = downloader.next_chunk()
                 logging.info(f"Download {status.progress()*100}%")
 
+    @retry_on_out_of_quota()
     def upload(self, from_file: Union[str, PosixPath], name: Optional[str]=None, mimetype: Optional[str]=None,
                parent_id: Optional[str]=None) -> str:
         """upload local file to gdrive.
@@ -54,6 +60,7 @@ class Drive:
                                             fields='id').execute()
         return file.get("id")
 
+    @retry_on_out_of_quota()
     def update(self, id: str, from_file: Union[str, PosixPath]):
         """update the Google drive with local file.
 
@@ -66,6 +73,7 @@ class Drive:
 
         self._service.files().update(body=dict(), fileId=id, media_body=media).execute()
 
+    @retry_on_out_of_quota()
     def get_id(self, name: str, parent_id: Optional[str]=None):
         """get the id of the file with specified name. if more than one file are found, an error will be raised.
 
@@ -90,6 +98,7 @@ class Drive:
 
         return item[0]['id']
 
+    @retry_on_out_of_quota()
     def find(self, name_contains: Optional[str]=None, name_not_contains: Optional[str]=None,
              parent_id: Optional[str]=None) -> list:
         """find all files whose name contain specified string and do not contain specified string. Note that Google
@@ -125,6 +134,7 @@ class Drive:
         item = response.get('files', [])
         return item
 
+    @retry_on_out_of_quota()
     def list(self, id: str, regex: str=None, recursive: bool=False, depth: int=3) -> list:
         """list the content of the folder by the given id.
 
@@ -157,6 +167,7 @@ class Drive:
 
         return result
 
+    @retry_on_out_of_quota()
     def delete(self, id: str, recursive: bool=False):
         """delete target file from google drive
         TODO: implement recursive delete
@@ -167,6 +178,7 @@ class Drive:
         """
         self._service.files().delete(fileId=id).execute()
 
+    @retry_on_out_of_quota()
     def create_folder(self, name: str, parent_ids: Optional[list]=None) -> str:
         """create a folder on google drive by the given name.
 
@@ -190,6 +202,7 @@ class Drive:
         folder = self._service.files().create(body=file_metadata, fields='id').execute()
         return folder.get("id")
 
+    @retry_on_out_of_quota()
     def share(self, id: str, emails: List[str], role: str= "reader", notify=True):  # pragma: no cover
         """modify the permission of the target object and share with the provided emails.
 
@@ -235,6 +248,7 @@ class Drive:
 
         return f"nextPageToken, files({','.join(fields)})"
 
+    @retry_on_out_of_quota()
     def get_name(self, id: str) -> str:
         """get the name of the Google drive object.
 
@@ -244,6 +258,7 @@ class Drive:
         file = self._service.files().get(fileId=id).execute()
         return file['name']
 
+    @retry_on_out_of_quota()
     def copy(self, id: str, name: str, parent_id: Optional[str]=None) -> str:
         """copy target file and give the new file specified name. return the id of the created file.
 

--- a/pysuite/sheets.py
+++ b/pysuite/sheets.py
@@ -15,6 +15,12 @@ class Sheets:
     """provide api to operate google spreadsheet. An authenticated google api client is needed.
     """
     def __init__(self, service: Resource, max_retry: int=0, sleep: int=5):
+        """
+
+        :param service: an authorized Google Spreadsheet service client.
+        :param max_retry: max number of retry on quota exceeded error. if 0 or less, no retry will be attempted.
+        :param sleep: base number of seconds between retries. the sleep time is exponentially increased after each retry.
+        """
         self._service = service.spreadsheets()
         setattr(self, MAX_RETRY_ATTRIBUTE, max_retry)
         setattr(self, SLEEP_ATTRIBUTE, sleep)

--- a/pysuite/utilities.py
+++ b/pysuite/utilities.py
@@ -1,0 +1,36 @@
+import functools
+import re
+import warnings
+import time
+
+from googleapiclient.errors import HttpError
+
+MAX_RETRY_ATTRIBUTE = "max_retry"
+SLEEP_ATTRIBUTE = "sleep"
+
+
+def retry_on_out_of_quota():
+    def wrapper(method):
+        @functools.wraps(wrapped=method)
+        def wrapped_function(self, *args, **kwargs):
+            max_retry = getattr(self, MAX_RETRY_ATTRIBUTE, 0)
+            max_retry = max(max_retry, 0)
+            sleep = getattr(self, SLEEP_ATTRIBUTE, 5)
+            pattern = re.compile(".*(User Rate Limit Exceeded|Quota exceeded)+.*")
+            while max_retry >= 0:
+                try:
+                    result = method(self, *args, **kwargs)
+                    return result
+                except HttpError as e:
+                    if pattern.match(str(e)):
+                        max_retry -= 1
+                        warnings.warn(f"handled exception {e}. remaining retry: {max_retry}", UserWarning)
+                        time.sleep(sleep)
+                        sleep = sleep**2
+                        continue
+
+                    raise e
+
+        return wrapped_function
+
+    return wrapper

--- a/pysuite/utilities.py
+++ b/pysuite/utilities.py
@@ -17,16 +17,16 @@ def retry_on_out_of_quota():
             max_retry = max(max_retry, 0)
             sleep = getattr(self, SLEEP_ATTRIBUTE, 5)
             pattern = re.compile(".*(User Rate Limit Exceeded|Quota exceeded)+.*")
-            while max_retry >= 0:
+            while True:
+                max_retry -= 1
                 try:
                     result = method(self, *args, **kwargs)
                     return result
                 except HttpError as e:
-                    if pattern.match(str(e)):
-                        max_retry -= 1
+                    if max_retry >= 0 and pattern.match(str(e)):
                         warnings.warn(f"handled exception {e}. remaining retry: {max_retry}", UserWarning)
                         time.sleep(sleep)
-                        sleep = sleep**2
+                        sleep = sleep*2
                         continue
 
                     raise e

--- a/pysuite/utilities.py
+++ b/pysuite/utilities.py
@@ -10,6 +10,13 @@ SLEEP_ATTRIBUTE = "sleep"
 
 
 def retry_on_out_of_quota():
+    """A decorator to give wrapped function ability to retry on quota exceeded related HttpError raise by Google API.
+    It only works on class method and requires "max_retry" and "sleep" attribute in the class. If `max_retry` is
+    non-positive, no retry will be attempt. `sleep` is the base number of seconds between consecutive retries. The number
+    of wait seconds will double after each sleep.
+
+    :return:
+    """
     def wrapper(method):
         @functools.wraps(wrapped=method)
         def wrapped_function(self, *args, **kwargs):

--- a/pysuite/utilities.py
+++ b/pysuite/utilities.py
@@ -16,6 +16,9 @@ def retry_on_out_of_quota():
             max_retry = getattr(self, MAX_RETRY_ATTRIBUTE, 0)
             max_retry = max(max_retry, 0)
             sleep = getattr(self, SLEEP_ATTRIBUTE, 5)
+            if sleep < 0:
+                raise AttributeError(f"{SLEEP_ATTRIBUTE} must be positive. Got {sleep}")
+
             pattern = re.compile(".*(User Rate Limit Exceeded|Quota exceeded)+.*")
             while True:
                 max_retry -= 1

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -10,7 +10,7 @@ from tests.helper import TEST_DRIVE_FOLDER_ID, purge_temp_file, prefix
 
 @pytest.fixture()
 def drive(drive_auth):
-    return Drive(service=drive_auth.get_service_client(), max_retry=3, sleep=5)
+    return Drive(service=drive_auth.get_service_client(), max_retry=5, sleep=10)
 
 
 def test_get_id_return_correct_value(drive):

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -10,7 +10,7 @@ from tests.helper import TEST_DRIVE_FOLDER_ID, purge_temp_file, prefix
 
 @pytest.fixture()
 def drive(drive_auth):
-    return Drive(service=drive_auth.get_service_client())
+    return Drive(service=drive_auth.get_service_client(), max_retry=3, sleep=5)
 
 
 def test_get_id_return_correct_value(drive):

--- a/tests/test_sheet.py
+++ b/tests/test_sheet.py
@@ -16,7 +16,7 @@ test_sheet_folder = "1qqFJ-OaV1rdPSeFtdaf6lUwFIpupOiiF"
 
 @pytest.fixture(scope="session")
 def sheets(sheets_auth):
-    return Sheets(service=sheets_auth.get_service_client(), max_retry=3, sleep=5)
+    return Sheets(service=sheets_auth.get_service_client(), max_retry=5, sleep=10)
 
 
 @pytest.mark.parametrize(("dimension", "range", "force_fill", "expected"),

--- a/tests/test_sheet.py
+++ b/tests/test_sheet.py
@@ -16,7 +16,7 @@ test_sheet_folder = "1qqFJ-OaV1rdPSeFtdaf6lUwFIpupOiiF"
 
 @pytest.fixture(scope="session")
 def sheets(sheets_auth):
-    return Sheets(service=sheets_auth.get_service_client())
+    return Sheets(service=sheets_auth.get_service_client(), max_retry=3, sleep=5)
 
 
 @pytest.mark.parametrize(("dimension", "range", "force_fill", "expected"),

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,70 @@
+import pytest
+
+from googleapiclient.errors import HttpError
+
+from pysuite.utilities import retry_on_out_of_quota, MAX_RETRY_ATTRIBUTE, SLEEP_ATTRIBUTE
+
+
+class TestClass:
+
+    def __init__(self, fail_times: int, max_retry: int, sleep: int):
+        self.fail_times = fail_times
+        setattr(self, MAX_RETRY_ATTRIBUTE, max_retry)
+        setattr(self, SLEEP_ATTRIBUTE, sleep)
+
+
+    @retry_on_out_of_quota()
+    def foo(self, err_msg: str):
+        error = b'{"error": {"message": "wow", "details": "dummy", }}'
+
+        class DummyResponse:
+            @property
+            def reason(self):
+                return err_msg
+
+            @property
+            def status(self):
+                return 403
+
+        reason = DummyResponse()
+
+        while self.fail_times > 0:
+            self.fail_times -= 1
+            raise HttpError(reason, error)
+
+
+@pytest.mark.parametrize("error_msg",
+                         [
+                             "oh User Rate Limit Exceeded wow",
+                             "Quota exceeded what do we do"
+                         ])
+def test_retry_on_out_of_quota_retry_correctly(error_msg):
+    test_class = TestClass(fail_times=2, max_retry=3, sleep=0.1)
+
+    with pytest.warns(UserWarning) as record:
+        test_class.foo(error_msg)
+
+    assert len(record) == 2
+
+
+@pytest.mark.parametrize("error_msg",
+                         [
+                             "oh User Rate Limit Exceeded wow",
+                             "Quota exceeded what do we do"
+                         ])
+def test_retry_on_out_of_quota_max_retry_fewer_than_fail_time_raise_error_correctly(error_msg):
+    test_class = TestClass(fail_times=2, max_retry=1, sleep=0.1)
+
+    with pytest.raises(HttpError), pytest.warns(UserWarning) as record:
+        test_class.foo(error_msg)
+
+    assert len(record) == 1
+
+
+def test_retry_on_out_of_quota_mismatch_error_raise_error_correctly():
+    test_class = TestClass(fail_times=1, max_retry=2, sleep=0.1)
+
+    with pytest.warns(None) as record, pytest.raises(HttpError):
+        test_class.foo("mismatching error msg")
+
+    assert len(record) == 0


### PR DESCRIPTION
# Changed
Add `max_retry` and `sleep` attributes to `Drive` and `Sheet` class. Allow many methods in `Drive` and `Sheet` class to retry when API Quota is reached.