### PR TITLE
refactor: refactor wrapper instantiation signature to use Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ You can then populate the oauth credential file that looks like:
 client secret file. For details, please see documentation.
 
 `Authentication` class provides one-stop-shop to prepare credentials and authentications
-for all clients in pysuites.
+for all clients in pysuite.
 
 ```python
 from pysuite import Authentication
 
 credential_json_file = "/tmp/credential.json"
-auth = Authentication(credential=credential_json_file, services=["storage", "vision"])
+auth = Authentication(credential=credential_json_file, project_id='my_project_id')
 ```

--- a/pysuite/auth.py
+++ b/pysuite/auth.py
@@ -4,13 +4,10 @@ import json
 import logging
 from pathlib import PosixPath
 from typing import Union, Optional, List
-from googleapiclient.discovery import build
 from google.auth.transport.requests import Request
 from google.auth.exceptions import RefreshError
 from google_auth_oauthlib.flow import Flow
 from google.oauth2.credentials import Credentials
-from google.cloud import vision as gv
-from google.cloud import storage
 
 
 SCOPES = {

--- a/pysuite/gmail.py
+++ b/pysuite/gmail.py
@@ -8,17 +8,25 @@ from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
 from typing import Union, Optional, List
 
+from googleapiclient.discovery import build
 from googleapiclient.discovery import Resource
+
+from pysuite.auth import Authentication
+
+
+def _get_client(auth: Authentication, version: str) -> Resource:
+    return build("gmail", version, credentials=auth.credential).users().messages()
 
 
 class GMail:
-    """A class containing methods to interact with Gmail APIs such as sending emails
+    """Implements methods to interact with Gmail APIs such as sending emails.
 
-    :param service: an authorized GMail service client.
+    :param auth: an authorized GMail service client.
+    :param version: version of API used. Default is "v1"
     """
 
-    def __init__(self, service: Resource):
-        self._service = service.users().messages()
+    def __init__(self, auth: Authentication, version: str = "v1"):
+        self._client = _get_client(auth, version)
 
     def compose(self, sender: str, to: Union[str, list], cc: Optional[Union[str, list]]=None,
                 bcc: Optional[Union[str, list]]=None, body: Optional[str]=None, subject: Optional[str]=None,
@@ -132,7 +140,7 @@ class GMail:
         """
         body = {'raw': urlsafe_b64encode(msg.as_bytes()).decode(),
                 'payload': {'mimeType': 'text/html'}}
-        response = self._service.send(userId=user_id, body=body).execute()
+        response = self._client.send(userId=user_id, body=body).execute()
         logging.debug(response)
         return response
 

--- a/pysuite/storage.py
+++ b/pysuite/storage.py
@@ -4,7 +4,7 @@ from pathlib import PosixPath, Path
 from typing import Union
 
 from google.cloud import storage
-from google.cloud.storage.client import Client, Bucket
+from google.cloud.storage.client import Bucket
 
 from pysuite.auth import Authentication
 

--- a/pysuite/storage.py
+++ b/pysuite/storage.py
@@ -3,19 +3,27 @@
 from pathlib import PosixPath, Path
 from typing import Union
 
+from google.cloud import storage
 from google.cloud.storage.client import Client, Bucket
 
+from pysuite.auth import Authentication
+
 GS_HEADER = "gs://"
+
+
+def _get_client(auth: Authentication):
+    return storage.Client(project=auth.project_id, credentials=auth.credential)
 
 
 class Storage:
     """Class to interact with Google Storage API.
 
-    :param service: an authorized Google Storage service client.
+    :param auth: An pysuite Authentication object.
+    :param project_id: The project id for the corresponding credential.
     """
 
-    def __init__(self, service: Client):
-        self._service = service
+    def __init__(self, auth: Authentication):
+        self._client = _get_client(auth)
 
     def upload(self, from_object: Union[str, PosixPath], to_object: str):
         """Upload a file or a folder to google storage. If `from_object` is a folder, this method will
@@ -112,7 +120,7 @@ class Storage:
         :param bucket_name: The name of the Google storage bucket.
         :return: None
         """
-        return self._service.create_bucket(bucket_name)
+        return self._client.create_bucket(bucket_name)
 
     def get_bucket(self, bucket_name: str) -> Bucket:
         """Get a Bucket object for the target Google storage bucket.
@@ -120,7 +128,7 @@ class Storage:
         :param bucket_name: The name of the target bucket.
         :return: A Bucket object for the target bucket.
         """
-        return self._service.get_bucket(bucket_name)
+        return self._client.get_bucket(bucket_name)
 
     def remove_bucket(self, bucket_name: str, force: bool = False):
         """Remove the target bucket.
@@ -130,7 +138,7 @@ class Storage:
           removed. Default is False.
         :return:
         """
-        bucket = self._service.get_bucket(bucket_name)
+        bucket = self._client.get_bucket(bucket_name)
         bucket.delete(force=force)
 
     def _split_gs_object(self, target_object: str) -> (str, str):

--- a/pysuite/vision.py
+++ b/pysuite/vision.py
@@ -1,6 +1,5 @@
 """Implement api to access google vision API
 """
-import logging
 import json
 from pathlib import PosixPath
 from typing import Union, Optional, List

--- a/pysuite/vision.py
+++ b/pysuite/vision.py
@@ -13,16 +13,21 @@ from google.cloud.vision_v1 import types, ImageAnnotatorClient
 from google.api_core.operation import Operation
 
 from pysuite.storage import is_gcs_uri
+from pysuite.auth import Authentication
+
+
+def _get_client(auth: Authentication) -> ImageAnnotatorClient:
+    return ImageAnnotatorClient(credentials=auth.credential)
 
 
 class Vision:
     """Class to interact with Google Vision API.
 
-    :param service: an authorized Google Vision service client.
+    :param auth: an authorized Google Vision service client.
     """
 
-    def __init__(self, service: ImageAnnotatorClient):
-        self._service = service
+    def __init__(self, auth: Authentication):
+        self._client = _get_client(auth)
         self._requests = []
 
     @staticmethod
@@ -69,7 +74,7 @@ class Vision:
         """
         request = self._create_request(image_path, methods)
 
-        response = self._service.annotate_image(request=request)
+        response = self._client.annotate_image(request=request)
         return response
 
     def batch_annotate_image(self) -> Optional[BatchAnnotateImagesResponse]:
@@ -83,7 +88,7 @@ class Vision:
             warnings.warn("No requests was prepared", UserWarning)
             return
 
-        response = self._service.batch_annotate_images(requests=self._requests)
+        response = self._client.batch_annotate_images(requests=self._requests)
         return response
 
     def async_annotate_image(self, output_gcs_uri: str, batch_size: int = 0) -> Optional[Operation]:
@@ -104,7 +109,7 @@ class Vision:
             "batch_size": batch_size
         }
 
-        response = self._service.async_batch_annotate_images(requests=self._requests, output_config=output_config)
+        response = self._client.async_batch_annotate_images(requests=self._requests, output_config=output_config)
         return response
 
     @staticmethod

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,10 +4,7 @@ import pytest
 from pathlib import PosixPath
 import json
 
-from googleapiclient.discovery import Resource
 from google.auth.exceptions import RefreshError
-from google.cloud.vision_v1 import ImageAnnotatorClient
-from google.cloud.storage.client import Client as StorageClient
 from google.oauth2.credentials import Credentials
 
 from pysuite.auth import Authentication, load_oauth, get_token_from_secrets_file

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -47,11 +47,6 @@ def test_load_oauth_raise_error_with_bad_type():
         load_oauth(123)
 
 
-def test_when_mixing_cloud_and_non_cloud_service_raise_exception_correctly():
-    with pytest.raises(ValueError):
-        Authentication(credential=token_file, services=["drive", "vision"])
-
-
 def test_authentication_log_correctly_when_refresh_error(caplog):
     cred_dict = {
         "client_id": "bad_client_id",
@@ -61,7 +56,7 @@ def test_authentication_log_correctly_when_refresh_error(caplog):
         "token_uri": "https://oauth2.googleapis.com/token",
     }
     with pytest.raises(RefreshError), caplog.at_level(logging.CRITICAL):
-        Authentication(credential=cred_dict, services=["gmail"])
+        Authentication(credential=cred_dict)
 
     result = caplog.records[0].message
     expected = "Unable to refresh oauth credentials. You may need to manually update oauth file."
@@ -69,75 +64,5 @@ def test_authentication_log_correctly_when_refresh_error(caplog):
 
 
 @pytest.fixture(scope="session")
-def drive_auth():
-    return Authentication(credential=token_file, services="drive")
-
-
-def test_get_client_from_drive_auth_return_correct_values(drive_auth):
-    result = drive_auth.get_service_client()
-    assert isinstance(result, Resource)
-
-
-@pytest.fixture(scope="session")
-def sheets_auth():
-    return Authentication(credential=token_file, services="sheets")
-
-
-def test_get_client_from_sheets_auth_return_correct_values(sheets_auth):
-    result = sheets_auth.get_service_client()
-    assert isinstance(result, Resource)
-
-
-@pytest.fixture(scope="session")
-def gmail_auth():
-    return Authentication(credential=token_file, services="gmail")
-
-
-def test_get_client_from_gmail_auth_return_correct_values(gmail_auth):
-    result = gmail_auth.get_service_client()
-    assert isinstance(result, Resource)
-
-
-@pytest.fixture(scope="session")
-def vision_auth():
-    return Authentication(credential=token_file, services="vision")
-
-
-def test_get_client_from_vision_auth_return_correct_values(vision_auth):
-    result = vision_auth.get_service_client()
-    assert isinstance(result, ImageAnnotatorClient)
-
-
-@pytest.fixture(scope="session")
-def multi_auth():
-    return Authentication(credential=token_file,
-                          services=["drive", "sheets", "gmail"])
-
-
-@pytest.mark.parametrize("service",
-                         ["drive", "sheets", "gmail"])
-def test_get_service_when_multiple_service_authorized_return_service_correctly(multi_auth, service):
-    result = multi_auth.get_service_client(service=service)
-    assert isinstance(result, Resource)
-
-
-def test_get_service_when_multiple_service_authorized_and_no_service_arg_passed_raise_exception(multi_auth):
-    with pytest.raises(ValueError):
-        multi_auth.get_service_client()
-
-
-@pytest.mark.parametrize("service",
-                         [None, "invalid_service"])
-def test_get_service_when_service_not_authorized_raise_exception(multi_auth, service):
-    with pytest.raises(ValueError):
-        multi_auth.get_service_client(service=service)
-
-
-@pytest.fixture(scope="session")
-def storage_auth():
-    return Authentication(credential=token_file, services="storage", project_id=test_project_id)
-
-
-def test_get_client_from_storage_auth_return_correct_values(storage_auth):
-    result = storage_auth.get_service_client()
-    assert isinstance(result, StorageClient)
+def auth_fixture():
+    return Authentication(credential=token_file, project_id=test_project_id)

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -4,13 +4,13 @@ from pathlib import Path
 from pysuite.drive import Drive
 from googleapiclient.errors import HttpError
 
-from tests.test_auth import drive_auth, multi_auth
+from tests.test_auth import auth_fixture
 from tests.helper import TEST_DRIVE_FOLDER_ID, purge_temp_file, prefix
 
 
 @pytest.fixture()
-def drive(drive_auth):
-    return Drive(service=drive_auth.get_service_client(), max_retry=5, sleep=10)
+def drive(auth_fixture):
+    return Drive(auth=auth_fixture, max_retry=5, sleep=10)
 
 
 def test_get_id_return_correct_value(drive):
@@ -139,13 +139,6 @@ def test_create_folder_correctly(drive, clean_folder, prefix):
     expected = f"{prefix}create_folder"
     id = drive.create_folder(expected, parent_ids=[folder_id])
     result = drive.get_name(id)
-    assert result == expected
-
-
-def test_multi_auth_token(multi_auth):
-    drive = Drive(multi_auth.get_service_client("drive"))
-    result = drive.get_name("1-zIfn0kUcK6KI9PfZLXu6uCt01ZSOTOZ")
-    expected = "drive_test_file"
     assert result == expected
 
 

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -3,12 +3,12 @@ import pytest
 from pysuite.gmail import GMail
 
 from tests.helper import resource_folder
-from tests.test_auth import gmail_auth, multi_auth
+from tests.test_auth import auth_fixture
 
 
 @pytest.fixture()
-def gmail(gmail_auth):
-    return GMail(service=gmail_auth.get_service_client())
+def gmail(auth_fixture):
+    return GMail(auth=auth_fixture)
 
 
 @pytest.mark.parametrize(("body", "to", "local_files", "gdrive_ids"),

--- a/tests/test_sheet.py
+++ b/tests/test_sheet.py
@@ -6,8 +6,8 @@ from pandas.testing import assert_frame_equal
 from googleapiclient.errors import HttpError
 
 from pysuite.sheets import Sheets, get_col_counts_from_range, get_column_number
-from tests.test_auth import sheets_auth, multi_auth
-from tests.test_drive import drive, drive_auth
+from tests.test_auth import auth_fixture
+from tests.test_drive import drive
 from tests.helper import purge_temp_file, prefix
 
 test_sheet_id = "1CNOH3o2Zz05mharkLXuwX72FpRka8-KFpIm9bEaja50"
@@ -15,8 +15,8 @@ test_sheet_folder = "1qqFJ-OaV1rdPSeFtdaf6lUwFIpupOiiF"
 
 
 @pytest.fixture(scope="session")
-def sheets(sheets_auth):
-    return Sheets(service=sheets_auth.get_service_client(), max_retry=10, sleep=10)
+def sheets(auth_fixture):
+    return Sheets(auth=auth_fixture, max_retry=10, sleep=10)
 
 
 @pytest.mark.parametrize(("dimension", "range", "force_fill", "expected"),
@@ -156,17 +156,6 @@ def test_to_sheet_update_values_correctly(sheets, clean_up_sheet_creation):
     result = sheets.download(id=test_sheet_id, sheet_range=sheet_range)
     expected = [["col1", "col2"], ["a", "1"], ["", "2"], ["c", "3"]]
     assert result == expected
-
-
-def test_multi_auth_token(multi_auth):
-    sheets = Sheets(multi_auth.get_service_client("sheets"))
-    result = sheets.read_sheet(id=test_sheet_id, sheet_range="download!A1:C")
-    expected = pd.DataFrame({
-        "col1": ["1", "2", "3"],
-        "col2": ["a", "b", "c"],
-        "col3": ["10.15", "20.2", "0.59"]
-    })
-    assert_frame_equal(result, expected)
 
 
 @pytest.fixture()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -6,11 +6,12 @@ from google.cloud.storage.client import Bucket
 from google.api_core.exceptions import NotFound
 
 from pysuite.storage import Storage, _add_folder_tree_to_new_base_dir
-from tests.test_auth import storage_auth
+from tests.test_auth import auth_fixture
 from tests.helper import resource_folder, prefix_lower
 
 TEST_BUCKET = "pysuite_bucket"
 SINGLE_FILE = "base.txt"
+
 
 @pytest.fixture(scope="module")
 def tmp_bucket(prefix_lower):
@@ -18,8 +19,8 @@ def tmp_bucket(prefix_lower):
 
 
 @pytest.fixture()
-def storage(storage_auth):
-    return Storage(service=storage_auth.get_service_client())
+def storage(auth_fixture):
+    return Storage(auth=auth_fixture)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -4,16 +4,16 @@ from pathlib import Path
 import pytest
 
 from pysuite.vision import Vision
-from tests.test_auth import vision_auth
-from tests.test_storage import storage_auth, storage, prepare_env, create_bucket, prefix_lower, tmp_bucket
+from tests.test_auth import auth_fixture
+from tests.test_storage import storage, prepare_env, create_bucket, prefix_lower, tmp_bucket
 from tests.helper import resource_folder
 
 test_image = resource_folder / "vision_test_image.jpg"
 
 
 @pytest.fixture()
-def vision(vision_auth):
-    return Vision(service=vision_auth.get_service_client())
+def vision(auth_fixture):
+    return Vision(auth=auth_fixture)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Changed

1. All client classes now take Authentication object instead of requiring calling `get_service_client`.
2. Removed a few methods in Authentication. Now service types are no longer checked. Users need to make sure the credential permits the API used.